### PR TITLE
fix: `python` executable not required per PEP 394

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ else
   CAT_COMMAND = cat
   EXESUFX = 
   PATHSEP=/
-  LEXT?=$(shell python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
+  LEXT?=$(shell $(PYTHON_EXE) -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
   PYF_SRCS := $(PHOJET_SRCS) $(PYTHIA_SRCS) $(DPMJET_SRCS) $(DUMMY_SRCS)
 endif
 


### PR DESCRIPTION
Under [PEP 394](https://peps.python.org/pep-0394/), the required `python` command for Python 3 is only `python3`. Some distributions install `python` but many don't (some have a `python-is-python3` package). This replaces the remaining occurence of `python` by `$(PYTHON_EXE)`.