### PR TITLE
AMU12C for FLUKA

### DIFF
--- a/include/dpmjet/inc/dtflka
+++ b/include/dpmjet/inc/dtflka
@@ -14,7 +14,11 @@ cc                              by  Alfredo Ferrari  - 17-Sep-21 -------
      &                  LINP  , LOUT  , LDAT  , LPRI  , IFLEVG
       LOGICAL LHADCL
 
+#if defined(FLDOTINCL)
+      PARAMETER ( AMU12C = 9.3123890693621192D-01 )
+#else
       PARAMETER ( AMU12C = 9.3123868129206122D-01 )
+#endif
       PARAMETER ( EMV2GV = 1.D-03 )
       COMMON / DTFLKA / EHFLLO, EHFLHI, AMXPFR, IAPFLK, IZPFLK, IATFLK,
      &                  IZTFLK, NPHFLK, NTHFLK, LHADCL, LINP  , LOUT  ,


### PR DESCRIPTION
Set AMU12C to the value used in FLUKA.

We experienced several crashes that stem from a mismatch between the value of this variable in FLUKA and DPMJET.

N.B. Another different value is set in common/dpmjetIII193.pyf.
