### PR TITLE
Add iswmdl(6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 For current validation plots [click here](docs/figures/193/DPMJET-III-193-validation.pdf)
 
+19.3.6
+- Backport of a fix for [chromo](https://github.com/impy-project/chromo):
+- Removed old python lib build from Makefile
+- Added new `ISWmdl(6) = 4` flag forcing Pythia to accept decay settings defined in mdcy 
+
 19.3.5
 - rename any references to the code impy to chromo
 - changed verbosity level to LPRi > 0 for logo

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,9 @@ Config?=Release
 ifeq ($(CVendor),"GNU")
 	#  GNU
 	FC := $(or $(FC), gfortran)
-	F2PY_C = gnu95
-	ifeq ($(OS),Windows_NT)
-		F2PY_CCONF = --compiler=mingw32 --fcompiler=$(F2PY_C)
-	else
-		F2PY_CCONF = --compiler=unix --fcompiler=$(F2PY_C)
-	endif
 else
 	#  Intel
 	FC = ifort
-	F2PY_C = intelem
 endif
 
 #######################################################################
@@ -61,24 +54,8 @@ else
 	endif
 endif
 
-#######################################################################
-#
-#   F2PY
-#
-#######################################################################
-#general version for signature file extraction and linking
-PYTHON_EXE := $(or $(PYTHON_EXE), python3)
-
-#general version for signature file extraction and linking
-ifeq ($(Config),"Debug")
-	F2PY = $(PYTHON_EXE) -m numpy.f2py
-else
-	F2PY = $(PYTHON_EXE)  -m numpy.f2py --quiet
-endif
 #Linker
 LD = $(FC)
-#additional flags for linker
-F2PY_L = $(F2PY) 
 
 # Directories
 WORK_DIR = $(CURDIR)
@@ -111,10 +88,6 @@ APP_EXE :=$(subst ./src/exe/,,$(APP_EXE))
 
 DUMMY_SRCS :=$(wildcard ./common/*.f)
 DUMMY_OBJS :=$(DUMMY_SRCS:.f=.o)
-CHROMO_RANGEN_SRC := ../rangen.fpp
-CHROMO_RANGEN_OBJ := ../rangen.o
-CHROMO_LOGGING_SRC := ../logging.f
-CHROMO_LOGGING_OBJ := ../logging.o
 
 # Portability (I know that this is insane...)
 ifeq ($(OS),Windows_NT)
@@ -126,8 +99,6 @@ ifeq ($(OS),Windows_NT)
   EXESUFX = .exe
   PATHSEP2=\\
   PATHSEP=$(strip $(PATHSEP2))
-  # Shared library suffix
-  LEXT?=$(shell $(PYTHON_EXE) -c "import sysconfig; print('.cp' + sysconfig.get_config_var('py_version_nodot') + '-' + sysconfig.get_platform().replace('-','_') + sysconfig.get_config_var('EXT_SUFFIX'))")
   space := $(null) #
   comma := ,
   
@@ -141,7 +112,6 @@ ifeq ($(OS),Windows_NT)
   PYTHIA_SRCS_CMMA := $(subst /,\,$(strip $(PYTHIA_SRCS_CMMA)))
   DUMMY_SRCS_CMMA := $(subst /,\,$(strip $(DUMMY_SRCS_CMMA)))
   
-  PYF_SRCS := $(PHOJET_SRCS_CMMA) $(PYTHIA_SRCS_CMMA) $(DPMJET_SRCS_CMMA) $(DUMMY_SRCS_CMMA)
 else
   DEL_COMMAND = rm -rf
   MKDIR_COMMAND = mkdir -p
@@ -150,17 +120,7 @@ else
   CAT_COMMAND = cat
   EXESUFX = 
   PATHSEP=/
-  LEXT?=$(shell python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
-  PYF_SRCS := $(PHOJET_SRCS) $(PYTHIA_SRCS) $(DPMJET_SRCS) $(DUMMY_SRCS)
 endif
-
-DPMJET_FUNCS = pho_event dt_init dt_kkinc \
-idt_icihad dt_xsglau pycomp dt_initjs dt_rndmst dt_rndm dt_inucas idt_ipdgha dt_evtout
-DPMJET_FUNCS += pho_init pho_setpar poevt1 poevt2 pho_pname pho_pmass pho_setmdl \
-pho_setpdf pycomp pho_xsect pho_borncs pho_harmci pho_fitout pho_mcini pho_ptcut \
-pytune pho_rregpar pho_sregpar pho_prevnt ipho_pdg2id ipho_id2pdg pho_harint \
-CHROMO_openlogfile CHROMO_closelogfile pho_harxto pho_harxpt pho_setpcomb \
-dt_phoxs dt_xshn dt_flahad dt_title pho_ghhias dt_getptn init_rmmard
 
 INCLU = -I$(PYTHIA_INCS) -I$(PHOJET_INCS) -I$(DPMJET_INCS) -I$(DPMJET_FLUKA_INCS)
 
@@ -174,37 +134,11 @@ ifneq ($(FLINCINCL_DIR),)
   INCLU += -I$(FLINCINCL_DIR)
 endif
 
-ifeq ($(MAKECMDGOALS),pylib)
-CPPFLAGS += -DCHROMO
-endif
-
-pylib = _dpmjetIII193$(LEXT)
-
 all: exe 
-
-.PHONY: pylib
-pylib: $(pylib)
-
-$(pylib): _dpmjetIII193.pyf $(DPMJET_OBJS) $(PHOJET_OBJS) $(PYTHIA_OBJS) $(DUMMY_OBJS) $(CHROMO_RANGEN_OBJ) $(CHROMO_LOGGING_OBJ)
-	$(F2PY) -c $(F2PY_CCONF) -DCHROMO --opt="$(OPT)" \
-	     _dpmjetIII193.pyf $(DPMJET_OBJS) $(PHOJET_OBJS) $(PYTHIA_OBJS) $(DUMMY_OBJS) $(CHROMO_RANGEN_OBJ) $(CHROMO_LOGGING_OBJ)
-
-.PHONY: install
-install: $(pylib)
-	$(COPY_COMMAND) *$(LEXT) $(LIB_DIR)
 
 .PHONY: exe
 exe: $(APP_OBJS) lib/libDPMJET.a
 	$(foreach a, $(APP_EXE), $(LD) -o bin/$(a) ./src/exe/$(a).o -Llib -lDPMJET ${\n})
-
-_dpmjetIII193.pyf:
-	$(CAT_COMMAND) $(PYF_SRCS) $(CHROMO_RANGEN_SRC) $(CHROMO_LOGGING_SRC) > f2pytemp.f
-	gfortran -E -cpp $(CPPFLAGS) f2pytemp.f > f2py_cpp.f
-	$(F2PY) -m _dpmjetIII193 -h _dpmjetIII193.pyf \
-	--include-paths $(DPMJET_INCS):$(PHOJET_INCS):$(PYTHIA_INCS):$(DPMJET_FLUKA_INCS) \
-	--overwrite-signature only: $(DPMJET_FUNCS) : f2py_cpp.f
-	# $(DEL_COMMAND) f2pytemp.f f2py_cpp.f f2pytemp.s
-	$(F2PY) _dpmjetIII193.pyf
 
 lib/libDPMJET.a:  $(PHOJET_OBJS) $(PYTHIA_OBJS) $(DPMJET_OBJS) $(DUMMY_OBJS)
 	if [ ! -d lib ]; then $(MKDIR_COMMAND) lib; fi
@@ -213,22 +147,15 @@ lib/libDPMJET.a:  $(PHOJET_OBJS) $(PYTHIA_OBJS) $(DPMJET_OBJS) $(DUMMY_OBJS)
 .f.o:
 	$(FC) -c -cpp $(CPPFLAGS) $(OPT) $(INCLU) -o $@ $<
 
-$(CHROMO_RANGEN_OBJ): $(CHROMO_RANGEN_SRC)
-	$(FC) -c -cpp $(CPPFLAGS) $(OPT) $(INCLU) -o $@ $<
-
-$(CHROMO_LOGGING_OBJ): $(CHROMO_LOGGING_SRC)
-	$(FC) -c -cpp $(CPPFLAGS) $(OPT) $(INCLU) -o $@ $<   
-
 .PHONY: clean
 clean:
-	$(DEL_COMMAND) lib$(PATHSEP)libDPMJET.a *.so *.pyd common$(PATHSEP)*.o *.dSYM $(COPY_DUMP) *.o
+	$(DEL_COMMAND) lib$(PATHSEP)libDPMJET.a *.so common$(PATHSEP)*.o *.dSYM $(COPY_DUMP) *.o
 	$(DEL_COMMAND) *.o src$(PATHSEP)pythia$(PATHSEP)*.o src$(PATHSEP)phojet$(PATHSEP)*.o src$(PATHSEP)dpmjet$(PATHSEP)*.o src$(PATHSEP)exe$(PATHSEP)*.o $(COPY_DUMP)
 	$(DEL_COMMAND) *.s src$(PATHSEP)pythia$(PATHSEP)*.s src$(PATHSEP)phojet$(PATHSEP)*.s src$(PATHSEP)dpmjet$(PATHSEP)*.s src$(PATHSEP)exe$(PATHSEP)*.s $(COPY_DUMP)
 	$(DEL_COMMAND) $(addprefix bin$(PATHSEP),$(addsuffix $(EXESUFX), $(APP_EXE))) $(COPY_DUMP)
 
 .PHONY: distclean
 distclean: clean
-	$(DEL_COMMAND) _dpmjetIII193*
 
 # **************************
 # Variable printing target

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DPMJET-III and PHOJET
 
-## Version: 19.3.5
+## Version: 19.3.6
 
 ### Status: release
 

--- a/src/dpmjet/DT_TITLE.f
+++ b/src/dpmjet/DT_TITLE.f
@@ -12,7 +12,7 @@
  
       CHARACTER*6 cversi
       CHARACTER*11 cchang
-      DATA cversi , cchang/'19.3.5' , '16 Jan 2023'/
+      DATA cversi , cchang/'19.3.6' , '23 Aug 2023'/
  
       CALL DT_XTIME
  

--- a/src/phojet/PHO_FRAINI.f
+++ b/src/phojet/PHO_FRAINI.f
@@ -88,11 +88,18 @@ C  load optimized parameters
          PARj(42) = 1.0D0
          MSTj(12)= 2
       END IF
+C  Force pythia to follow the MDCy decay settings
+      IF ( idefab.GE.4 ) THEN
+         MSTj(21) = 1
+         MSTj(22) = 1
+      ENDIF
 C prevent particles from decaying
-      DO i = 1 , 35
-         kc = PYCOMP(idxsta(i))  
-         MDCy(kc,1) = 0
-      END DO
+      IF ( Idefau.LT.0) THEN
+         DO i = 1 , 35
+            kc = PYCOMP(idxsta(i))
+            MDCy(kc,1) = 0
+         END DO
+      END IF
 C prevent some charmed baryons which don't have a BAMJET code to be
 C set as stable
       DO i = 1 , NUNSTAB

--- a/src/phojet/PHO_INIT.f
+++ b/src/phojet/PHO_INIT.f
@@ -107,7 +107,7 @@ C initialize random number generator in standalone (-2) mode
       IF ( LPRi.GT.0 ) WRITE (LO,*) 
      &            '                                                    '
       IF ( LPRi.GT.0 ) WRITE (LO,*) 
-     &            '   ----        PHOJET  19.3.5       ----   '
+     &            '   ----        PHOJET  19.3.6       ----   '
       IF ( LPRi.GT.0 ) WRITE (LO,*) 
      &            '                                                    '
       IF ( LPRi.GT.0 ) WRITE (LO,*) 
@@ -128,8 +128,8 @@ C initialize random number generator in standalone (-2) mode
      &                    '     https://github.com/afedynitch/dpmjet'
       IF ( LPRi.GT.0 ) WRITE (LO,*) 
      &            ' ==================================================='
-      IF ( LPRi.GT.0 ) WRITE (LO,*) '   Date: 2023/01/16'
-      IF ( LPRi.GT.0 ) WRITE (LO,*) '   Revision: 19.3.5'
+      IF ( LPRi.GT.0 ) WRITE (LO,*) '   Date: 2023/08/23'
+      IF ( LPRi.GT.0 ) WRITE (LO,*) '   Revision: 19.3.6'
  
       IF ( LPRi.GT.0 ) WRITE (LO,*)
      &                         '   Code with interface to PYTHIA 6.4.27'

--- a/src/phojet/PHO_STRFRA.f
+++ b/src/phojet/PHO_STRFRA.f
@@ -60,7 +60,7 @@ C  color string configurations including collapsed strings and hadrons
       DIMENSION ijoin(MSCAHD)
  
       Irej = 0
-      IF ( ABS(ISWmdl(6)).GT.3 ) THEN
+      IF ( ABS(ISWmdl(6)).GT.4 ) THEN
          IF ( LPRi.GT.4 ) WRITE (LO,'(/1X,2A,I3)')
      &        'PHO_STRFRA:ERROR: ' , 'invalid value of ISWMDL(6)' , 
      &        ISWmdl(6)


### PR DESCRIPTION
Fixes #16 

- Backport of a fix for [chromo](https://github.com/impy-project/chromo)
- Removed old python lib build from Makefile
- Added new `ISWmdl(6) = 4` flag forcing Pythia to accept decay settings defined in mdcy 