### PR TITLE
Enable gamma-nucleon and gamma-nucleus collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,25 @@
 
 For current validation plots [click here](docs/figures/193/DPMJET-III-193-validation.pdf)
 
+19.3.7
+
+- Fix for photonuclear interactions in DPMJET and photon-hadron or photon-photon interactions in PHOJET
+- The fix switches between proton PDFs: CT14 for hadron projectiles and GRV for photon projectiles
+
 19.3.6
+
 - Backport of a fix for [chromo](https://github.com/impy-project/chromo):
 - Removed old python lib build from Makefile
-- Added new `ISWmdl(6) = 4` flag forcing Pythia to accept decay settings defined in mdcy 
+- Added new `ISWmdl(6) = 4` flag forcing Pythia to accept decay settings defined in mdcy
 
 19.3.5
+
 - rename any references to the code impy to chromo
 - changed verbosity level to LPRi > 0 for logo
 - changed some notation in Makefile
 
 19.3.4:
+
 - Different values for atomic mass of 12c depending on preprocessor flags
 - Change to python interface of `pho_init`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DPMJET-III and PHOJET
 
-## Version: 19.3.6
+## Version: 19.3.7
 
 ### Status: release
 

--- a/examples/dpmjet/gC.inp
+++ b/examples/dpmjet/gC.inp
@@ -25,14 +25,6 @@ ENERGY          920.0
 * the "PHOINPUT" and "ENDINPUT" cards.
 PHOINPUT
 PROCESS           1 0 1 1 1 1 1 1
-
-PDF              2212 5 6 0 
-PDF             -2212 5 6 0 
-PDF              2112 5 6 0 
-PDF             -2112 5 6 0 
-PDF              22   5 3 0
-PDF              990  4 0 0
-
 ENDINPUT
 *
 * Output

--- a/src/dpmjet/DT_LAEVT.f
+++ b/src/dpmjet/DT_LAEVT.f
@@ -18,8 +18,9 @@ C***********************************************************************
      &                 PI , pltot , ppn , ppt , ptotgn , ptotln , px , 
      &                 py , pz , q2e , q2log , q2low , q2tmp
       DOUBLE PRECISION rat , sid , sif , sigmax , sigxx , stot , stotx , 
-     &                 theta , THREE , TINY10 , TINY4 , TWO , TWOPI , 
-     &                 weight , wgh , wghmax , wgy , xbj , xblow , xdumb
+     &                 spro, sprox, theta , THREE , TINY10 , TINY4 ,
+     &                 TWO , TWOPI , weight , wgh , wghmax , wgy , xbj ,
+     &                 xblow , xdumb
       DOUBLE PRECISION y , yeff , yq2 , yy , yytmp , ZERO
       INTEGER i , i1 , i2 , Idp , idppdg , IDT_IPDGHA , ievt , Iglau , 
      &        ihfle0 , ihfle1 , ihfle2 , ihflq0 , ihflq1 , ihflq2 , 
@@ -388,12 +389,12 @@ C  force Lab-system
 C  get emulsion component if requested
 C  convolute with cross section
             IF ( IEMul.GT.0 ) CALL DT_GETEMU(Ntmass,Ntchar,kkmat,0)
-            CALL DT_SIGGAT(q2low,egnxx,stotx,kkmat)
-            CALL DT_SIGGAT(Q2,ecmgn,stot,kkmat)
+            CALL DT_SIGGAT(q2low,egnxx,stotx,sprox,kkmat)
+            CALL DT_SIGGAT(Q2,ecmgn,stot,spro,kkmat)
  
             IF ( LPRi.GT.4 .AND. stotx.LT.stot )
      &            WRITE (LOUt,'(1X,A,/,6E12.3)')
-     &            'LAEVT: warning STOTX<STOT ! ' , q2low , egnmax , 
+     &            'LAEVT: warning STOTX<STOT !`` ' , q2low , egnmax , 
      &           stotx , Q2 , ecmgn , stot
             IF ( DT_RNDM(Q2)*stotx.GT.stot ) GOTO 250
             nc1 = nc1 + 1

--- a/src/dpmjet/DT_PHOINI.f
+++ b/src/dpmjet/DT_PHOINI.f
@@ -217,10 +217,16 @@ C*sr 26.10.96
 C*
  
 C  Initialize phojet with protons and other hadrons on demand
-      CALL PHO_SETPAR(1,2212,0,ZERO)
+      CALL PHO_SETPAR(1,IDT_IPDGHA(ijp),0,ZERO)
       CALL PHO_SETPAR(2,2212,0,ZERO)
- 
       CALL PHO_EVENT(-1,pp,pt,sigmax,irej1)
+      WRITE (LOUt,*) 'PHOJET event-initialization from DPM!'
+      WRITE (LOUt,*) '  sigmax = ',sigmax
+      WRITE (LOUt,*) '  irej1  = ',irej1
+      WRITE(LOUt,*) '  pp = ',pp
+      WRITE(LOUt,*) '  pt = ',pt
+
+
  
 C*sr 26.10.96
       IPAmdl(13) = isav

--- a/src/dpmjet/DT_PHOINI.f
+++ b/src/dpmjet/DT_PHOINI.f
@@ -220,13 +220,6 @@ C  Initialize phojet with protons and other hadrons on demand
       CALL PHO_SETPAR(1,IDT_IPDGHA(ijp),0,ZERO)
       CALL PHO_SETPAR(2,2212,0,ZERO)
       CALL PHO_EVENT(-1,pp,pt,sigmax,irej1)
-      WRITE (LOUt,*) 'PHOJET event-initialization from DPM!'
-      WRITE (LOUt,*) '  sigmax = ',sigmax
-      WRITE (LOUt,*) '  irej1  = ',irej1
-      WRITE(LOUt,*) '  pp = ',pp
-      WRITE(LOUt,*) '  pt = ',pt
-
-
  
 C*sr 26.10.96
       IPAmdl(13) = isav

--- a/src/dpmjet/DT_SIGGA.f
+++ b/src/dpmjet/DT_SIGGA.f
@@ -24,7 +24,9 @@ C***********************************************************************
       PARAMETER (TINY10=1.0D-10,TINY2=1.0D-2,ZERO=0.0D0,DLARGE=1.0D10,
      &           OHALF=0.5D0,ONE=1.0D0)
       PARAMETER (AMPROT=0.938D0)
- 
+Cf2py intent(in) :: Nti, Xi, Q2i, Ecmi, Xnui
+Cf2py intent(out) :: Stot, Etot, Sin, Ein, Stot0
+
 C emulsion treatment
       INCLUDE 'inc/dtcomp'
  

--- a/src/dpmjet/DT_SIGGAT.f
+++ b/src/dpmjet/DT_SIGGAT.f
@@ -1,5 +1,5 @@
 
-      SUBROUTINE DT_SIGGAT(Q2i,Ecmi,Stot,Nt)
+      SUBROUTINE DT_SIGGAT(Q2i,Ecmi,Stot,Spro,Nt)
  
 C***********************************************************************
 C Total/inelastic photon-nucleus cross sections.                       *
@@ -8,11 +8,13 @@ C This version dated 29.07.96 is written by S. Roesler                 *
 C***********************************************************************
  
       IMPLICIT NONE
-      DOUBLE PRECISION Ecmi , ONE , Q2i , rate , ratq , Stot , TINY10 , 
-     &                 TINY14 , TWO , ZERO
+      DOUBLE PRECISION Ecmi , ONE , Q2i , rate , ratq , Stot ,  Spro,
+     &                 TINY10 ,TINY14 , TWO , ZERO
       INTEGER i , i1 , i2 , j1 , j2 , Nt , ntarg
       SAVE 
- 
+Cf2py intent(in) Q2i,Ecmi,Nt
+Cf2py intent(out) Stot,Spro
+
 #if defined(FLDOTINCL) && defined(FOR_FLUKA)
       INCLUDE 'inc/dtflka12ca'
 #else
@@ -75,5 +77,12 @@ C                 RATQ = (Q2I-Q2G(J1))/(Q2G(J2)-Q2G(J1))
      &       + ratq*(XSTot(i1,j2,ntarg)-XSTot(i1,j1,ntarg))
      &       + rate*ratq*(XSTot(i2,j2,ntarg)-XSTot(i1,j2,ntarg)
      &       +XSTot(i1,j1,ntarg)-XSTot(i2,j1,ntarg))
+
+      Spro = XSpro(i1,j1,ntarg)
+     &       + rate*(XSpro(i2,j1,ntarg)-XSpro(i1,j1,ntarg))
+     &       + ratq*(XSpro(i1,j2,ntarg)-XSpro(i1,j1,ntarg))
+     &       + rate*ratq*(XSpro(i2,j2,ntarg)-XSpro(i1,j2,ntarg)
+     &       +XSpro(i1,j1,ntarg)-XSpro(i2,j1,ntarg))
+
  
       END SUBROUTINE

--- a/src/dpmjet/DT_SIGGP.f
+++ b/src/dpmjet/DT_SIGGP.f
@@ -43,7 +43,8 @@ C*
 C     PARAMETER (NPOINT=80)
       PARAMETER (NPOINT=16)
       DIMENSION abszx(NPOINT) , weight(NPOINT)
- 
+Cf2py intent(in) :: Xi, Q2i, Ecmi, Xnui
+Cf2py intent(out) :: Stot, Sine, Sdir
       Stot = ZERO
       Sine = ZERO
       Sdir = ZERO

--- a/src/dpmjet/DT_TITLE.f
+++ b/src/dpmjet/DT_TITLE.f
@@ -12,7 +12,7 @@
  
       CHARACTER*6 cversi
       CHARACTER*11 cchang
-      DATA cversi , cchang/'19.3.6' , '23 Aug 2023'/
+      DATA cversi , cchang/'19.3.7' , '18 Mar 2023'/
  
       CALL DT_XTIME
  

--- a/src/dpmjet/DT_XSGLAU.f
+++ b/src/dpmjet/DT_XSGLAU.f
@@ -196,8 +196,7 @@ C  maximum impact-parameter
  
 C slope, rho ( Re(f(0))/Im(f(0)) )
       IF ( ((ijproj.LE.40) .OR. ((ijproj.GE.97) .AND. (ijproj.LE.103))
-     &     .OR. (ijproj.EQ.109) .OR. (ijproj.EQ.115)) .AND. 
-     &     (ijproj.NE.7) ) THEN
+     &     .OR. (ijproj.EQ.109) .OR. (ijproj.EQ.115)) ) THEN
          IF ( MCGene.EQ.2 ) THEN
             zero1 = ZERO
             CALL DT_PHOXS(ijproj,1,ECMnn(Ie),zero1,sdum1,sdum2,sdum3,

--- a/src/exe/DPMJET_direct.f
+++ b/src/exe/DPMJET_direct.f
@@ -10,8 +10,8 @@ C particle properties (BAMJET index convention)
       INCLUDE 'inc/dtpart'
 
       INCLUDE 'inc/dtflka'
-      DIMENSION IDPLIST(5)
-      DATA IDPLIST /2212,2112,-321,211,-211/
+      DIMENSION IDPLIST(6)
+      DATA IDPLIST /2212,2112,-321,211,-211, 22/
 
       SAVE
 
@@ -64,7 +64,7 @@ C  generate events
       WRITE(LOUT,*) 'Particle ID:', IDP, IDT_ICIHAD(IDP)
 
 C  number of events
-      NEVE = 10
+      NEVE = 1000
       ITRY = 0
       IREJ = 0
       KKMAT = -1
@@ -74,7 +74,7 @@ C  number of events
         ITRY = ITRY+1
 
 C       Random choice of projectile        
-        IRPRO = 1 + INT(DT_RNDM(DUM))*4.5D0
+        IRPRO = 1 + INT(DT_RNDM(DUM)*5.5D0)
         CALL dt_kkinc(NPMASS,NPCHAR,NTMASS,NTCHAR,
      &     IDT_ICIHAD(IDPLIST(IRPRO)),ELAB, KKMAT, IREJ)
 
@@ -98,8 +98,8 @@ C       event loop (Print particles stack)
             PZ = phkk(3,I)
             EE = phkk(4,I)
             AM = phkk(5,I)
-            WRITE(LOUT,'(3I6,5E12.3)') nevhkk, idhkk(I),idbam(I),
-     &        PX, PY, PZ, EE, AM
+C            WRITE(LOUT,'(3I6,5E12.3)') nevhkk, idhkk(I),idbam(I),
+C     &        PX, PY, PZ, EE, AM
 
           ENDIF
         ENDDO

--- a/src/exe/photo_hadronic.f
+++ b/src/exe/photo_hadronic.f
@@ -58,21 +58,6 @@ C  general initialization of PHOJET data structures (mandatory)
 C  (-2 means that no steering file is expected)
       irej = 20
       CALL PHO_INIT(-2,6,irej)
- 
-
-C Set PDFs to the "old" GRV98, since photon interactions are not
-C tuned to the CT14 default in the "new" DPMJET/PHOJET
-
-C  proton
-      CALL PHO_SETPDF(2212,IDUM,5,6,0,0,-1)
-      CALL PHO_SETPDF(-2212,IDUM,5,6,0,0,-1)
-C  neutron
-      CALL PHO_SETPDF(2112,IDUM,5,6,0,0,-1)
-      CALL PHO_SETPDF(-2112,IDUM,5,6,0,0,-1)
-C  photon
-      CALL PHO_SETPDF(22,IDUM,5,3,0,0,-1)
-C  pomeron
-      CALL PHO_SETPDF(990,IDUM,4,0,0,0,-1)
 
 C Set (real) photon for Side 1 (left). Last parameter is the
 C virtuality in case you need virtual photons

--- a/src/phojet/PHO_INIT.f
+++ b/src/phojet/PHO_INIT.f
@@ -107,7 +107,7 @@ C initialize random number generator in standalone (-2) mode
       IF ( LPRi.GT.0 ) WRITE (LO,*) 
      &            '                                                    '
       IF ( LPRi.GT.0 ) WRITE (LO,*) 
-     &            '   ----        PHOJET  19.3.6       ----   '
+     &            '   ----        PHOJET  19.3.7       ----   '
       IF ( LPRi.GT.0 ) WRITE (LO,*) 
      &            '                                                    '
       IF ( LPRi.GT.0 ) WRITE (LO,*) 
@@ -128,8 +128,8 @@ C initialize random number generator in standalone (-2) mode
      &                    '     https://github.com/afedynitch/dpmjet'
       IF ( LPRi.GT.0 ) WRITE (LO,*) 
      &            ' ==================================================='
-      IF ( LPRi.GT.0 ) WRITE (LO,*) '   Date: 2023/08/23'
-      IF ( LPRi.GT.0 ) WRITE (LO,*) '   Revision: 19.3.6'
+      IF ( LPRi.GT.0 ) WRITE (LO,*) '   Date: 2024/03/18'
+      IF ( LPRi.GT.0 ) WRITE (LO,*) '   Revision: 19.3.7'
  
       IF ( LPRi.GT.0 ) WRITE (LO,*)
      &                         '   Code with interface to PYTHIA 6.4.27'

--- a/src/phojet/PHO_SETPAR.f
+++ b/src/phojet/PHO_SETPAR.f
@@ -20,7 +20,7 @@ C**********************************************************************
  
       SAVE 
  
-      INTEGER Iside , Idpdg , Idcpc
+      INTEGER Iside , Idpdg , Idcpc, idum, phmode
       DOUBLE PRECISION Pvir
  
 C  input/output channels
@@ -38,20 +38,40 @@ C  general particle data
 C  particle decay data
       INCLUDE 'inc/popar3'
  
+C  local variables
+      INTEGER i , idcpcn , idcpcr , idpdgn , idpdgr , idb , ifl1 , 
+     &        ifl2 , ifl3
+      DATA phmode / 0 /
 C  external functions
       INTEGER IPHO_PDG2ID , IPHO_CHR3 , IPHO_BAR3
       DOUBLE PRECISION PHO_PMASS
  
-C  local variables
-      INTEGER i , idcpcn , idcpcr , idpdgn , idpdgr , idb , ifl1 , 
-     &        ifl2 , ifl3
  
       IF ( IDEb(87).GE.15 ) THEN
          IF ( LPRi.GT.4 ) WRITE (LO,'(1X,A,I2,/5X,A,2I6)')
      &         'PHO_SETPAR: called for side' , Iside , 'IDPDG, IDCPC' , 
      &        Idpdg , Idcpc
       END IF
- 
+
+      IF ((phmode.EQ.0).AND.(ISide.EQ.1).AND.(Idpdg.EQ.22)) THEN
+C  proton
+         CALL PHO_SETPDF(2212,IDUM,5,6,0,0,-1)
+         CALL PHO_SETPDF(-2212,IDUM,5,6,0,0,-1)
+c  neutron
+         CALL PHO_SETPDF(2112,IDUM,5,6,0,0,-1)
+         CALL PHO_SETPDF(-2112,IDUM,5,6,0,0,-1)
+         phmode = 1
+      ELSE IF ((phmode.EQ.1).AND.(ISide.EQ.1).AND.
+     &   (Idpdg.NE.22)) THEN
+C  proton
+         CALL PHO_SETPDF(2212,idum,2,1,0,0,-1)
+         CALL PHO_SETPDF(-2212,idum,2,1,0,0,-1)
+C  neutron
+         CALL PHO_SETPDF(2112,idum,2,1,0,0,-1)
+         CALL PHO_SETPDF(-2112,idum,2,1,0,0,-1)
+         phmode = 0
+      END IF
+
       IF ( (Iside.EQ.1) .OR. (Iside.EQ.2) ) THEN
          idcpcn = Idcpc
 C  remnant?

--- a/src/phojet/PHO_SETPDF.f
+++ b/src/phojet/PHO_SETPDF.f
@@ -90,7 +90,8 @@ C  nucleon-nucleus / nucleus-nucleus interface to DPMJET
       ELSE IF ( Mode.EQ.-1 ) THEN
          DO i = 1 , ientry
             IF ( Idpdg.EQ.ipdfs(1,i) ) THEN
-               IF ( LPRi.GT.4 ) WRITE (LO,'(/1X,A,5I6)')
+               IF ( (LPRi.GT.4) .AND. (IDEb(80).GT.0) ) 
+     &            WRITE (LO,'(/1X,A,5I6)')
      &               'PHO_SETPDF: overwrite old particle PDF' , Idpdg , 
      &              ipdfs(2,i) , ipdfs(3,i) , ipdfs(4,i) , ipdfs(5,i)
                GOTO 150


### PR DESCRIPTION
Since the major update in 2015, the generator didn't properly work for photon projectiles. One reason was that the PDFs for hadrons moved to CT14. This implied that many parameters had to be retuned, and it was done for hadrons and checked for nuclei, but nothing has been done for photons. Hence there were no parameter sets for photon - proton.\

Another reason is the dimensional extension of the cross section tables. It was done to implement dynamical switching between different projectile target combinations in run time.

This PR is a fix because the tables have not been redone with CT14 and instead, the code switched between old and new PDFs when needed. 

The feature has been requested by many people. 